### PR TITLE
Remove `anonfiles.com` and `filechan.org`

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -11,7 +11,6 @@
 ---
 
 ## 匿名网盘  
-- [AnonFile](https://anonfiles.com) – 单个文件上限 20 GB；无带宽限制  
 - [filechan](https://filechan.org/) – 同上  
 - [ufile](https://ufile.io) – 单个文件上限 5 GB  
 - [uptobox](https://uptobox.com/) – 单个文件上限 1 GB  

--- a/docs/content.md
+++ b/docs/content.md
@@ -10,8 +10,7 @@
 
 ---
 
-## 匿名网盘  
-- [filechan](https://filechan.org/) – 同上  
+## 匿名网盘    
 - [ufile](https://ufile.io) – 单个文件上限 5 GB  
 - [uptobox](https://uptobox.com/) – 单个文件上限 1 GB  
 


### PR DESCRIPTION
Remove `anonfiles.com` and `filechan.org` because the service has been decommissioned.

RE: https://web.archive.org/web/20230915221219/https://anonfiles.com/

> After trying endlessly for two years to run a file sharing site with user anonymity we have been tired of handling the extreme volumes of people abusing it and the headaches it has created for us.
Maybe it is hard to understand but after tens of million uploads and many petabytes later all work of handling abuse was automated through all available channels to be fast as possible.
We have auto banned contents of hundreds of thousands files.
Banned file names and also banned specific usage patterns connected to abusive material to the point where we did not care if we accidental delete thousands of false positive in this process.
Even after all this the high volume of abuse will not stop.
This is not the kind of work we imagine when acquiring it and recently our proxy provider shut us down.
This can not continue.
Domain 4sale.
domain @ anonfiles . com

RE: https://web.archive.org/web/20230000000000*/filechan.org

`filechan.org` no longer has a valid DNS record.

```bash
$ dig A filechan.org @8.8.8.8

; <<>> DiG 9.18.12-0ubuntu0.22.04.2-Ubuntu <<>> A filechan.org @8.8.8.8
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 15440
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;filechan.org.			IN	A

;; AUTHORITY SECTION:
filechan.org.		1800	IN	SOA	1-you.njalla.no. you.can-get-no.info. 2023091215 21600 7200 1814400 3600
```
